### PR TITLE
Fix CLI argument parsing for logging options

### DIFF
--- a/src/npg/cli.py
+++ b/src/npg/cli.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2023 Genome Research Ltd. All rights reserved.
+# Copyright © 2023, 2025 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -111,12 +111,12 @@ def add_io_arguments(parser: ArgumentParser) -> ArgumentParser:
 def add_logging_arguments(parser: ArgumentParser) -> ArgumentParser:
     """Adds standard CLI logging arguments to a parser.
 
-    - --log-config Use a log configuration file (mutually exclusive with --debug,
-        --verbose, --colour and --json).
+    - --log-config Use a log configuration file.
     - -d/--debug   Enable DEBUG level logging to STDERR.
     - -v/--verbose Enable INFO level logging to STDERR.
+
     - --colour     Use coloured log rendering to the console.
-    - --json       Use JSON log rendering.
+    - --log-json   Use JSON log rendering.
 
     Args:
         parser: An argument parser to modify.
@@ -124,34 +124,36 @@ def add_logging_arguments(parser: ArgumentParser) -> ArgumentParser:
     Returns:
         The parser
     """
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument(
+    group1 = parser.add_mutually_exclusive_group()
+    group1.add_argument(
         "--log-config",
         "--log_config",
         help="A logging configuration file.",
         type=str,
     )
-    group.add_argument(
+    group1.add_argument(
         "-d",
         "--debug",
         help="Enable DEBUG level logging to STDERR.",
         action="store_true",
     )
-    group.add_argument(
+    group1.add_argument(
         "-v",
         "--verbose",
         help="Enable INFO level logging to STDERR.",
         action="store_true",
     )
 
-    parser.add_argument(
-        "--json",
-        help="Use JSON log rendering.",
-        action="store_true",
-    )
-    parser.add_argument(
+    group2 = parser.add_mutually_exclusive_group()
+    group2.add_argument(
         "--colour",
         help="Use coloured log rendering to the console.",
+        action="store_true",
+    )
+    group2.add_argument(
+        "--log-json",
+        "--log_json",
+        help="Use JSON log rendering.",
         action="store_true",
     )
 

--- a/src/npg/conf.py
+++ b/src/npg/conf.py
@@ -44,7 +44,7 @@ class IniData:
     a specified dataclass. Using a dataclass results in configuration that is easier
     to understand and more maintainable than using a bare dictionary because all its
     fields are explicitly defined. This means that they are readable, navigable and
-    autocomplete-able in an IDE, can have default values, and can have docstrings.
+    autocomplete-able in an IDE and can have default values and docstrings.
 
     E.g. given an INI file 'config.ini':
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2025 Genome Research Ltd. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+
+import pytest
+
+from npg.cli import add_logging_arguments
+
+
+class TestArgParser:
+    def test_logging_args_config_group(self):
+        p1 = argparse.ArgumentParser()
+        add_logging_arguments(p1)
+        with pytest.raises(SystemExit):
+            p1.parse_args(["--log-config", "config.json", "--debug"])
+
+        p2 = argparse.ArgumentParser()
+        add_logging_arguments(p2)
+        with pytest.raises(SystemExit):
+            p2.parse_args(["--log-config", "config.json", "--verbose"])
+
+        p3 = argparse.ArgumentParser()
+        add_logging_arguments(p3)
+        with pytest.raises(SystemExit):
+            p3.parse_args(["--debug", "--verbose"])
+
+    def test_logging_args_format_group(self):
+        parser = argparse.ArgumentParser()
+        add_logging_arguments(parser)
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--colour", "--log-json"])


### PR DESCRIPTION
The JSON and colour options should be mutually exclusive. Neither of these options should be mutually exclusive with the error level filtering options.

The JSON option should be --log-json (not --json).

N.B. Bump to version 1.0 when releasing this.