### PR TITLE
Parse some INI file fields to the declared type

### DIFF
--- a/src/npg/conf.py
+++ b/src/npg/conf.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import configparser
 import dataclasses
 import os
 from configparser import ConfigParser
@@ -153,7 +152,7 @@ class IniData:
             dataclass=self.dataclass,
         )
 
-        parser = configparser.ConfigParser()
+        parser = ConfigParser()
         if not parser.read(p):
             raise ParseError(f"Could not read '{p}'")
 

--- a/src/npg/conf.py
+++ b/src/npg/conf.py
@@ -201,8 +201,7 @@ class IniData:
     def parse_ini_value(self, parser: ConfigParser, section: str, field, hint) -> Any:
         """
         Parses the value of a field from a configuration file, converting it to its
-        specified type or hint. If the value is absent or empty, it attempts to return
-        a default value based on the provided type hint.
+        specified type or hint.
 
         Args:
             parser: Configuration parser object used to read values.
@@ -212,7 +211,7 @@ class IniData:
                 conversion.
 
         Returns:
-        The parsed value converted to the type specified by the hint.
+            The parsed value converted to the type specified by the hint.
         """
         parsed_val = None
 
@@ -247,11 +246,11 @@ class IniData:
         """
         Parses an environment variable value and converts it to the specified type.
 
-        This function takes a string value and a type hint, converting the string into the
-        desired type. It supports basic data types such as `str`, `int`, `float`, `bool`,
-        and instances of `Path`. Optional types for these primitive or file path types are
-        also supported. If an unsupported type is provided in the hint, a `ValueError`
-        will be raised.
+        This function takes a string value and a type hint, converting the string into
+        the desired type. It supports the basic data types `str`, `int`, `float`, `bool`,
+        and instances of `Path`. Optional types for these primitive or file path types
+        are also supported. If an unsupported type is provided in the hint, a
+        ValueError` is raised.
 
         Args:
             val: The string value to convert.

--- a/src/npg/conf.py
+++ b/src/npg/conf.py
@@ -21,7 +21,7 @@ import os
 from dataclasses import dataclass
 from os import PathLike
 from pathlib import Path
-from typing import TypeVar
+from typing import Optional, TypeVar, get_type_hints
 
 from structlog import get_logger
 
@@ -84,7 +84,9 @@ class IniData:
         parser = IniData(ServerConfig, use_env=True, env_prefix="SERVER_").
         obj = from_file("config.ini", "server")
 
-    All values are treated as strings.
+    All values are treated as strings except where the dataclass declares its field
+    types as int, float, bool or Path (or Optional versions of these), in which case
+    the string is parsed into the appropriate type.
 
     The class provides INFO level logging of its actions to enable loading of
     configurations to be traced.
@@ -150,10 +152,13 @@ class IniData:
         if not parser.read(p):
             raise ParseError(f"Could not read '{p}'")
 
+        hints = get_type_hints(self.dataclass)
         kwargs = {}
         for field in dataclasses.fields(self.dataclass):
+            hint = hints.get(field.name, None)
+
             if parser.has_option(section, field.name):
-                val = parser.get(section, field.name)
+                val = _parse_field(parser, section, field, hint)
 
                 if val is None and self.use_env:
                     env_var = self.env_prefix.upper() + field.name.upper()
@@ -164,8 +169,7 @@ class IniData:
                         field=field.name,
                         env_var=env_var,
                     )
-
-                    val = os.environ.get(env_var)
+                    val = _parse_value(os.environ.get(env_var), hint)
 
                 kwargs[field.name] = val
 
@@ -180,10 +184,63 @@ class IniData:
                     env_var=env_var,
                 )
 
-                kwargs[field.name] = os.environ.get(env_var)
+                kwargs[field.name] = _parse_value(os.environ.get(env_var), hint)
 
         instance = self.dataclass(**kwargs)
-
         log.debug("Reading complete", instance=instance)
 
         return instance
+
+
+def _parse_field(parser, section: str, field, hint):
+    val = None
+
+    strval = parser.get(section, field.name)
+
+    if hint is str:
+        val = strval
+    elif hint is int and strval:
+        val = parser.getint(section, field.name)
+    elif hint is float and strval:
+        val = parser.getfloat(section, field.name)
+    elif hint is bool and strval:
+        val = parser.getboolean(section, field.name)
+    elif hint is Path and strval:
+        val = Path(parser.get(section, field.name))
+    elif hint is Optional[str]:
+        val = parser.get(section, field.name)
+    elif hint is Optional[int] and strval:
+        val = parser.getint(section, field.name)
+    elif hint is Optional[float] and strval:
+        val = parser.getfloat(section, field.name)
+    elif hint is Optional[bool] and strval:
+        val = parser.getboolean(section, field.name)
+    elif hint is Optional[Path] and strval:
+        val = Path(parser.get(section, field.name))
+
+    return val
+
+
+def _parse_value(val: str, hint):
+    if hint is str:
+        return val
+    elif hint is int:
+        return int(val)
+    elif hint is float:
+        return float(val)
+    elif hint is bool:
+        return val.lower() == "true"
+    elif hint is Path:
+        return Path(val)
+    elif hint is Optional[str]:
+        return val
+    elif hint is Optional[int]:
+        return int(val) if val else None
+    elif hint is Optional[float]:
+        return float(val) if val else None
+    elif hint is Optional[bool]:
+        return val.lower() == "true" if val else None
+    elif hint is Optional[Path]:
+        return Path(val) if val else None
+    else:
+        raise ValueError(f"Unsupported type '{hint}'")


### PR DESCRIPTION
Where dataclasses declare the type of a field, parse the INI file value to that type, if possible. Also parse environment variable fallback values.

Support int, float, bool and pathlib.Path